### PR TITLE
Fix fallback when emacsclient failed

### DIFF
--- a/pinentry-emacs
+++ b/pinentry-emacs
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o pipefail
 echo OK
 while read cmd rest
 do


### PR DESCRIPTION
Without pipefail, even if emacsclient failed, `$?` is 0.